### PR TITLE
Add category to TOC

### DIFF
--- a/Broker_MicroMenu.toc
+++ b/Broker_MicroMenu.toc
@@ -1,7 +1,7 @@
 ## Interface: @toc-version-retail@, @toc-version-midnight@
 #@debug@
 ## Interface: 120000
-#@end-debug@>
+#@end-debug@
 ## Interface-Retail: @toc-version-retail@
 ## Interface-Classic: @toc-version-classic@
 ## Interface-BCC: @toc-version-bcc@

--- a/Broker_MicroMenu.toc
+++ b/Broker_MicroMenu.toc
@@ -15,6 +15,17 @@
 ## SavedVariables: Broker_MicroMenuDB
 ## X-Curse-Project-ID: 21420
 
+## Category: Data Broker
+## Category-deDE: Datenbroker
+## Category-esES: Intermediario de Datos
+## Category-esMX: Intermediario de Datos
+## Category-frFR: Courtier de Données
+## Category-itIT: Data Broker
+## Category-ptBR: Corretor de Dados
+## Category-ruRU: Посредник данных
+## Category-zhCN: 数据管理
+## Category-zhTW: 資料管理
+
 #@no-lib-strip@
 libs\libs.xml
 #@end-no-lib-strip@


### PR DESCRIPTION
I added the Data Broker category to the TOC; this makes it group up with other broker addons in the WoW addon list.

The translations are taken from the suggested list of categories on the WoW wiki: https://warcraft.wiki.gg/wiki/Addon_Categories#Data_Broker